### PR TITLE
set_epoch functionality

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1886,6 +1886,7 @@ dependencies = [
  "fvm_ipld_hamt",
  "fvm_shared",
  "multihash",
+ "replace_with",
  "thiserror",
 ]
 

--- a/api/src/lib.rs
+++ b/api/src/lib.rs
@@ -62,6 +62,8 @@ pub trait Bench {
 
     /// Returns the VM's current epoch.
     fn epoch(&self) -> ChainEpoch;
+    /// Replaces the VM in the workbench with a new set to the specified epoch
+    fn set_epoch(&mut self, epoch: ChainEpoch);
     /// Returns a reference to the VM's blockstore.
     fn store(&self) -> &dyn Blockstore;
     /// Looks up a top-level actor state object in the VM.

--- a/api/src/wrangler.rs
+++ b/api/src/wrangler.rs
@@ -86,6 +86,10 @@ impl ExecutionWrangler {
         self.bench.borrow().epoch()
     }
 
+    pub fn set_epoch(&self, epoch: ChainEpoch) {
+        self.bench.borrow_mut().set_epoch(epoch);
+    }
+
     pub fn find_actor(&self, id: ActorID) -> anyhow::Result<Option<ActorState>> {
         self.bench.borrow().find_actor(id)
     }

--- a/builtin/tests/datacap_tests.rs
+++ b/builtin/tests/datacap_tests.rs
@@ -44,8 +44,8 @@ fn datacap_transfer_scenario() {
     let spec = GenesisSpec::default(manifest_data_cid);
     let genesis = create_genesis_actors(&mut builder, &spec).unwrap();
 
-    let mut bench = builder.build().unwrap();
-    let mut w = ExecutionWrangler::new_default(&mut *bench);
+    let bench = builder.build().unwrap();
+    let mut w = ExecutionWrangler::new_default(bench);
 
     let accts = create_accounts(
         &mut w,

--- a/builtin/tests/market_tests.rs
+++ b/builtin/tests/market_tests.rs
@@ -65,15 +65,14 @@ fn publish_storage_deals() {
     let spec = GenesisSpec::default(manifest_data_cid);
     let genesis = create_genesis_actors(&mut builder, &spec).unwrap();
 
-    let mut bench = builder.build().unwrap();
-    let mut w = ExecutionWrangler::new_default(&mut *bench);
+    let bench = builder.build().unwrap();
+    let mut w = ExecutionWrangler::new_default(bench);
 
     let (a, deal_start) = setup(&mut w, &genesis);
     let mut batcher =
         DealBatcher::new(a.maddr, PaddedPieceSize(1 << 30), false, deal_start, DEAL_LIFETIME);
 
-    let mut options = DealOptions::default();
-    options.verified = Some(true);
+    let options = DealOptions { verified: Some(true), ..Default::default() };
     batcher.stage(&a.verified_client, "deal0", options.clone());
     batcher.stage(&a.verified_client, "deal1", options.clone());
     batcher.stage(&a.verified_client, "deal2", options.clone());

--- a/builtin/tests/util/hookup.rs
+++ b/builtin/tests/util/hookup.rs
@@ -27,9 +27,9 @@ fn test_hookup() {
 
     let spec = GenesisSpec::default(manifest_data_cid);
     let genesis = create_genesis_actors(&mut builder, &spec).unwrap();
-    let mut bench = builder.build().unwrap();
+    let bench = builder.build().unwrap();
 
-    let mut wrangler = ExecutionWrangler::new_default(&mut *bench);
+    let mut wrangler = ExecutionWrangler::new_default(bench);
     let result = wrangler
         .execute(
             genesis.faucet_address(),

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.63.0"
+channel = "1.64.0"
 components = ["clippy", "rustfmt"]
 targets = ["wasm32-unknown-unknown"]

--- a/vm/Cargo.toml
+++ b/vm/Cargo.toml
@@ -17,6 +17,7 @@ fvm_ipld_amt = { version = "0.5.1", features = ["go-interop"] }
 fvm_ipld_car = { version = "~0.6.0"}
 fvm_ipld_blockstore = { version = "~0.1.1"}
 fvm_ipld_encoding = "0.3.3"
+replace_with = "0.1.7"
 
 anyhow = "~1.0.47"
 cid = { version = "~0.8.5", default-features = false }

--- a/vm/src/bench.rs
+++ b/vm/src/bench.rs
@@ -88,6 +88,17 @@ where
             let mut machine_ctx = machine.context().clone();
             machine_ctx.epoch = epoch;
             machine_ctx.initial_state_root = machine.flush().unwrap();
+
+            // TODO: there is currently no way to get the externs out of the machine.
+            // Machine::externs(&self) does exist but since the above line machine.into_store() takes ownership of the
+            // machine we cannot borrow it again.
+            //
+            // Alternatives here that would allow us to keep the generic flexibility over externs
+            //
+            // - add a function to Machine to allow a single function that takes ownership and returns a tuple of blockstore, externs
+            // - add a function to Machine that allows explicit mutation of the MachineContext. Though this seems like a bit of an anti-pattern. My understanding is that the Machine shouldn't really mutate but rather new machines should be instantiated per epoch. But maybe this is ok.
+            // - have FakeExterns implement Clone and then clone the externs out of the machine before taking ownership of the machine
+            // - have FakeExterns be an indirection to user-provided functionality
             let machine = DefaultMachine::new(
                 &machine_ctx,
                 machine.into_store().into_inner(),

--- a/vm/src/bench.rs
+++ b/vm/src/bench.rs
@@ -1,7 +1,7 @@
 use anyhow::anyhow;
 use fvm::call_manager::DefaultCallManager;
+use fvm::engine::EnginePool;
 use fvm::executor::{ApplyKind, ApplyRet, DefaultExecutor, Executor};
-use fvm::externs::Externs;
 use fvm::machine::{DefaultMachine, Machine};
 use fvm::trace::ExecutionEvent;
 use fvm::DefaultKernel;
@@ -14,31 +14,31 @@ use fvm_workbench_api::trace::ExecutionEvent::{Call, CallError, CallReturn, GasC
 use fvm_workbench_api::trace::ExecutionTrace;
 use fvm_workbench_api::{ActorState, Bench, ExecutionResult};
 
+use crate::externs::FakeExterns;
+
 /// A workbench instance backed by a real FVM.
-pub struct FvmBench<B, E>
+pub struct FvmBench<B>
 where
-    B: Blockstore + 'static,
-    E: Externs + 'static,
+    B: Blockstore + Clone + 'static,
 {
-    executor: BenchExecutor<B, E>,
+    executor: BenchExecutor<B>,
 }
 
-type BenchExecutor<B, E> = DefaultExecutor<DefaultKernel<DefaultCallManager<DefaultMachine<B, E>>>>;
+type BenchExecutor<B> =
+    DefaultExecutor<DefaultKernel<DefaultCallManager<DefaultMachine<B, FakeExterns>>>>;
 
-impl<B, E> FvmBench<B, E>
+impl<B> FvmBench<B>
 where
-    B: Blockstore,
-    E: Externs,
+    B: Blockstore + Clone,
 {
-    pub fn new(executor: BenchExecutor<B, E>) -> Self {
+    pub fn new(executor: BenchExecutor<B>) -> Self {
         Self { executor }
     }
 }
 
-impl<B, E> Bench for FvmBench<B, E>
+impl<B> Bench for FvmBench<B>
 where
-    B: Blockstore,
-    E: Externs,
+    B: Blockstore + Clone,
 {
     fn execute(&mut self, msg: Message, msg_length: usize) -> anyhow::Result<ExecutionResult> {
         self.executor.execute_message(msg, ApplyKind::Explicit, msg_length).map(ret_as_result)
@@ -79,6 +79,28 @@ where
             .state_tree()
             .lookup_id(addr)
             .map_err(|e| anyhow!("failed to resolve address {}: {}", addr, e.to_string()))
+    }
+
+    fn set_epoch(&mut self, epoch: ChainEpoch) {
+        replace_with::replace_with_or_abort(&mut self.executor, |e| {
+            let mut machine = e.into_machine().unwrap();
+            let engine_conf = (&machine.context().network).into();
+            let mut machine_ctx = machine.context().clone();
+            machine_ctx.epoch = epoch;
+            machine_ctx.initial_state_root = machine.flush().unwrap();
+            let machine = DefaultMachine::new(
+                &machine_ctx,
+                machine.into_store().into_inner(),
+                FakeExterns::new(),
+            )
+            .unwrap();
+
+            DefaultExecutor::<DefaultKernel<DefaultCallManager<DefaultMachine<B, FakeExterns>>>>::new(
+                EnginePool::new_default(engine_conf).unwrap(),
+                machine,
+            )
+            .unwrap()
+        });
     }
 }
 


### PR DESCRIPTION
Some experimentation with getting a set_epoch to work though there are some caveats. In general, supporting a bunch of generics makes this stream of work harder. Though in the short-medium term I expect certain elements of the testing stack, Externs, Blockstore etc. will only need one implementation

The progress in https://github.com/anorth/fvm-workbench/tree/valid_precommits_test depends on set_epoch