### PR TITLE
Prefactor Bench

### DIFF
--- a/builtin/tests/datacap_tests.rs
+++ b/builtin/tests/datacap_tests.rs
@@ -44,8 +44,8 @@ fn datacap_transfer_scenario() {
     let spec = GenesisSpec::default(manifest_data_cid);
     let genesis = create_genesis_actors(&mut builder, &spec).unwrap();
 
-    let bench = builder.build().unwrap();
-    let mut w = ExecutionWrangler::new_default(bench);
+    let mut bench = builder.build().unwrap();
+    let mut w = ExecutionWrangler::new_default(&mut *bench);
 
     let accts = create_accounts(
         &mut w,

--- a/builtin/tests/market_tests.rs
+++ b/builtin/tests/market_tests.rs
@@ -65,8 +65,8 @@ fn publish_storage_deals() {
     let spec = GenesisSpec::default(manifest_data_cid);
     let genesis = create_genesis_actors(&mut builder, &spec).unwrap();
 
-    let bench = builder.build().unwrap();
-    let mut w = ExecutionWrangler::new_default(bench);
+    let mut bench = builder.build().unwrap();
+    let mut w = ExecutionWrangler::new_default(&mut *bench);
 
     let (a, deal_start) = setup(&mut w, &genesis);
     let mut batcher =

--- a/builtin/tests/util/hookup.rs
+++ b/builtin/tests/util/hookup.rs
@@ -27,9 +27,9 @@ fn test_hookup() {
 
     let spec = GenesisSpec::default(manifest_data_cid);
     let genesis = create_genesis_actors(&mut builder, &spec).unwrap();
-    let bench = builder.build().unwrap();
+    let mut bench = builder.build().unwrap();
+    let mut wrangler = ExecutionWrangler::new_default(&mut *bench);
 
-    let mut wrangler = ExecutionWrangler::new_default(bench);
     let result = wrangler
         .execute(
             genesis.faucet_address(),


### PR DESCRIPTION
See https://github.com/anorth/fvm-workbench/pull/6#discussion_r1191820626 for an example motivating use case.

This should make future access to kernel/primitives/blockstore etc. easier when using the ExecutionWrangler. 

Alternative is for ExecutionWrangler to retain ownership of the Bench and expose a transactional method that exposes the Bench via a closure.