### PR TITLE
Derive InvocationTrace from ExecutionTrace

### DIFF
--- a/.github/workflows/benchmark-builtins.yml
+++ b/.github/workflows/benchmark-builtins.yml
@@ -1,10 +1,12 @@
 name: Benchmark builtin actors
 
 on:
+  # Benchmarks can be run manually from the `Run workflow` dropdown https://github.com/anorth/fvm-workbench/actions/workflows/benchmark-builtins.yml
+  # Or, they are run automatically on benchmark-* branches (which can be used to target different builtin-actor bundles)
   workflow_dispatch:
   push:
     branches:
-      - main
+      - benchmark-*
 
 jobs:
   benchmark-builtins:

--- a/api/src/analysis.rs
+++ b/api/src/analysis.rs
@@ -50,9 +50,7 @@ impl TraceAnalysis {
                     spans.push(Span::new(span_id));
                     call_stack.push(spans.len() - 1);
                 }
-                ExecutionEvent::CallReturn { .. }
-                | ExecutionEvent::CallAbort { .. }
-                | ExecutionEvent::CallError { .. } => {
+                ExecutionEvent::CallReturn { .. } | ExecutionEvent::CallError { .. } => {
                     // Pop from call stack
                     let closed_idx = call_stack.pop().unwrap();
                     let closed_span = spans.get_mut(closed_idx).unwrap();

--- a/api/src/trace.rs
+++ b/api/src/trace.rs
@@ -53,9 +53,6 @@ pub enum ExecutionEvent {
         return_value: Option<IpldBlock>,
         exit_code: ExitCode,
     },
-    CallAbort {
-        exit_code: ExitCode,
-    },
     CallError {
         reason: String,
         errno: ErrorNumber,
@@ -74,6 +71,7 @@ impl From<ExecutionTrace> for InvocationTrace {
 impl From<&ExecutionTrace> for InvocationTrace {
     fn from(e_trace: &ExecutionTrace) -> InvocationTrace {
         let mut invocation_stack: Vec<InvocationTrace> = Vec::new();
+        let mut root_invocation: Option<InvocationTrace> = None;
 
         for event in e_trace.events.iter() {
             match event {
@@ -85,15 +83,15 @@ impl From<&ExecutionTrace> for InvocationTrace {
                         method: *method,
                         params: params.clone(),
                         value: value.clone(),
-                        code: ExitCode::OK, // Placeholder, will be updated during return
+                        code: ExitCode::OK, // Placeholder, will be updated during call return
                         ret: None,          // Placeholder, will be updated during return
-                        subinvocations: Vec::new(),
+                        subinvocations: Vec::new(), // Placeholder, will be updated if subinvocations are made
                     });
                 }
                 ExecutionEvent::CallReturn { return_value, exit_code } => {
                     let mut current_invocation = invocation_stack
                         .pop()
-                        .unwrap_or_else(|| panic!("Unmatched call return: {:?}", e_trace));
+                        .unwrap_or_else(|| panic!("Unmatched CallReturn: {:?}", e_trace));
 
                     current_invocation.code = *exit_code;
                     current_invocation.ret = return_value.clone();
@@ -101,41 +99,39 @@ impl From<&ExecutionTrace> for InvocationTrace {
                     if let Some(parent_invocation) = invocation_stack.last_mut() {
                         parent_invocation.subinvocations.push(current_invocation);
                     } else {
-                        // At root invocation
-                        return current_invocation;
-                    }
-                }
-                ExecutionEvent::CallAbort { exit_code } => {
-                    let mut current_invocation = invocation_stack
-                        .pop()
-                        .unwrap_or_else(|| panic!("Unmatched call abort: {:?}", e_trace));
-
-                    current_invocation.code = *exit_code;
-
-                    if let Some(parent_invocation) = invocation_stack.last_mut() {
-                        parent_invocation.subinvocations.push(current_invocation);
-                    } else {
-                        // At root invocation
-                        return current_invocation;
+                        // At root invocation, assign to the root call
+                        if root_invocation.is_some() {
+                            panic!("Attempting to assign multiple root invocations: {:?}", e_trace);
+                        }
+                        root_invocation = Some(current_invocation);
                     }
                 }
                 ExecutionEvent::CallError { .. } => {
                     let mut current_invocation = invocation_stack
                         .pop()
-                        .unwrap_or_else(|| panic!("Unmatched call error: {:?}", e_trace));
+                        .unwrap_or_else(|| panic!("Unmatched CallError: {:?}", e_trace));
 
+                    // TODO(alexytsu): have invocation trace store ErrorNumber | ExitCode
+                    // blocked by: https://github.com/filecoin-project/builtin-actors/issues/1365
                     current_invocation.code = ExitCode::SYS_ASSERTION_FAILED;
 
                     if let Some(parent_invocation) = invocation_stack.last_mut() {
                         parent_invocation.subinvocations.push(current_invocation);
                     } else {
-                        // At root invocation
-                        return current_invocation;
+                        // At root invocation, assign to the root call
+                        if root_invocation.is_some() {
+                            panic!("Attempting to assign multiple root invocations: {:?}", e_trace);
+                        }
+                        root_invocation = Some(current_invocation);
                     }
                 }
             }
         }
 
-        panic!("Malformed ExecutionTrace: {:?}", e_trace)
+        if !invocation_stack.is_empty() {
+            panic!("Malformed ExecutionTrace, leftover invocations in stack: {:?}", e_trace);
+        }
+
+        root_invocation.expect("Malformed ExecutionTrace, missing root invocation")
     }
 }

--- a/api/src/wrangler.rs
+++ b/api/src/wrangler.rs
@@ -121,8 +121,11 @@ impl ExecutionWrangler {
         self.bench.borrow().resolve_address(addr)
     }
 
-    pub fn peek_execution_trace(&self) -> Vec<ExecutionTrace> {
-        self.execution_results.borrow().clone()
+    /// Returns a copy of the last execution trace if any exist
+    /// For test assertions you probably want VM::take_invocations instead
+    /// NOTE: These traces will be cleared if take_invocations was called earlier
+    pub fn peek_execution_trace(&self) -> Option<ExecutionTrace> {
+        self.execution_results.borrow().last().cloned()
     }
 }
 
@@ -242,6 +245,7 @@ impl VM for ExecutionWrangler {
         self.bench.borrow_mut().set_epoch(epoch)
     }
 
+    /// Note: this is derived from the underlying ExecutionTraces, so it will clear those when taken
     fn take_invocations(&self) -> Vec<InvocationTrace> {
         self.execution_results.take().into_iter().map(InvocationTrace::from).collect()
     }

--- a/api/src/wrangler.rs
+++ b/api/src/wrangler.rs
@@ -153,20 +153,6 @@ impl ExecutionWrangler {
         self.bench.borrow().resolve_address(addr)
     }
 
-    /// Returns a reference to the underlying blockstore
-    /// The blockstore handle here is intended to be short-lived as some executors may buffer changes leading to this
-    /// handle drifting out of sync
-    // TODO: https://github.com/anorth/fvm-workbench/issues/15
-    pub fn store(&self) -> &dyn Blockstore {
-        // It's unfortunate that we need to call flush here everytime we need the wrangler to give out a blockstore reference
-        // However, the state_tree inside Executor wraps whatever blockstore it's given with a BufferedBlockstore
-        // Since the store held by the Wrangler was cloned prior to being wrapped in the BufferedBlockstore, it's possible
-        // there are pending changes to the underlying blockstore held in the BufferedBlockstore's cache that are not
-        // visible via our handle.
-        self.bench.borrow_mut().flush();
-        self.store.as_ref()
-    }
-
     fn make_msg(
         &self,
         from: Address,

--- a/builtin/tests/hookup.rs
+++ b/builtin/tests/hookup.rs
@@ -7,7 +7,6 @@ use fvm_shared::state::StateTreeVersion;
 use fvm_shared::version::NetworkVersion;
 use fvm_shared::METHOD_SEND;
 use fvm_workbench_api::analysis::TraceAnalysis;
-// use fvm_workbench_api::analysis::TraceAnalysis;
 use fvm_workbench_api::bench::WorkbenchBuilder;
 use fvm_workbench_api::wrangler::ExecutionWrangler;
 use fvm_workbench_builtin_actors::genesis::{
@@ -48,8 +47,7 @@ fn test_hookup() {
 
     assert_eq!(ExitCode::OK, result.code);
 
-    let traces = wrangler.peek_execution_trace();
-    let trace = traces.get(0).unwrap();
+    let trace = wrangler.peek_execution_trace().unwrap();
     println!("{}", trace.format());
     let analysis = TraceAnalysis::build(trace.clone());
     println!("{}", analysis.format_spans());

--- a/builtin/tests/hookup.rs
+++ b/builtin/tests/hookup.rs
@@ -6,6 +6,7 @@ use fvm_shared::error::ExitCode;
 use fvm_shared::state::StateTreeVersion;
 use fvm_shared::version::NetworkVersion;
 use fvm_shared::METHOD_SEND;
+use fvm_workbench_api::analysis::TraceAnalysis;
 // use fvm_workbench_api::analysis::TraceAnalysis;
 use fvm_workbench_api::bench::WorkbenchBuilder;
 use fvm_workbench_api::wrangler::ExecutionWrangler;
@@ -47,8 +48,9 @@ fn test_hookup() {
 
     assert_eq!(ExitCode::OK, result.code);
 
-    // TODO: re-enable traces after https://github.com/anorth/fvm-workbench/issues/19 is completed
-    // println!("{}", result.trace.format());
-    // let analysis = TraceAnalysis::build(result.trace);
-    // println!("{}", analysis.format_spans());
+    let traces = wrangler.peek_execution_trace();
+    let trace = traces.get(0).unwrap();
+    println!("{}", trace.format());
+    let analysis = TraceAnalysis::build(trace.clone());
+    println!("{}", analysis.format_spans());
 }


### PR DESCRIPTION
Closes https://github.com/anorth/fvm-workbench/issues/19

This allows the `withdraw_balance_success_test` imported from builtin-actors to fully pass