### PR TITLE
Workbench Bug Fixes

### DIFF
--- a/api/src/bench.rs
+++ b/api/src/bench.rs
@@ -42,7 +42,7 @@ pub trait WorkbenchBuilder {
 
     /// Creates a workbench ready to execute messages.
     /// The System and Init actors must be created before a workbench can be built or used.
-    fn build(&mut self) -> anyhow::Result<Box<dyn Bench>>;
+    fn build(&mut self, circulating_supply: TokenAmount) -> anyhow::Result<Box<dyn Bench>>;
 }
 
 /// A VM workbench that can execute messages to actors.

--- a/builtin/src/genesis.rs
+++ b/builtin/src/genesis.rs
@@ -1,5 +1,4 @@
 use cid::Cid;
-use fil_actors_integration_tests::TEST_FAUCET_ADDR;
 use fil_actors_runtime::runtime::builtins::Type;
 use fil_actors_runtime::{
     make_empty_map, BURNT_FUNDS_ACTOR_ADDR, BURNT_FUNDS_ACTOR_ID, CRON_ACTOR_ID,

--- a/builtin/src/lib.rs
+++ b/builtin/src/lib.rs
@@ -1,3 +1,4 @@
+use fil_actors_integration_tests::TEST_FAUCET_ADDR;
 use fvm_actor_utils::shared_blockstore::SharedMemoryBlockstore;
 use fvm_shared::{state::StateTreeVersion, version::NetworkVersion};
 use fvm_workbench_api::{bench::WorkbenchBuilder, wrangler::ExecutionWrangler};
@@ -21,7 +22,9 @@ pub fn setup() -> ExecutionWrangler {
     )
     .unwrap();
     let spec = GenesisSpec::default(manifest_data_cid);
-    let _genesis = create_genesis_actors(&mut builder, &spec).unwrap();
+    let genesis = create_genesis_actors(&mut builder, &spec).unwrap();
+    // check that the genesis state matches assumptions in the builtin-actors test code
+    assert_eq!(genesis.faucet_id, TEST_FAUCET_ADDR.id().unwrap());
     let bench = builder.build().unwrap();
     ExecutionWrangler::new_default(bench, Box::new(store), Box::new(FakePrimitives {}))
 }

--- a/builtin/src/lib.rs
+++ b/builtin/src/lib.rs
@@ -25,6 +25,7 @@ pub fn setup() -> ExecutionWrangler {
     let genesis = create_genesis_actors(&mut builder, &spec).unwrap();
     // check that the genesis state matches assumptions in the builtin-actors test code
     assert_eq!(genesis.faucet_id, TEST_FAUCET_ADDR.id().unwrap());
-    let bench = builder.build().unwrap();
+    let circulating_supply = spec.reward_balance + spec.faucet_balance;
+    let bench = builder.build(circulating_supply).unwrap();
     ExecutionWrangler::new_default(bench, Box::new(store), Box::new(FakePrimitives {}))
 }

--- a/builtin/tests/hookup.rs
+++ b/builtin/tests/hookup.rs
@@ -31,7 +31,8 @@ fn test_hookup() {
 
     let spec = GenesisSpec::default(manifest_data_cid);
     let genesis = create_genesis_actors(&mut builder, &spec).unwrap();
-    let bench = builder.build().unwrap();
+    let circulating_supply = spec.reward_balance + spec.faucet_balance;
+    let bench = builder.build(circulating_supply).unwrap();
     let wrangler =
         ExecutionWrangler::new_default(bench, Box::new(store), Box::new(FakePrimitives {}));
 

--- a/vm/src/bench/mod.rs
+++ b/vm/src/bench/mod.rs
@@ -148,6 +148,11 @@ where
         let manifest = self.executor.builtin_actors();
         let mut map = BTreeMap::new();
 
+        let system = manifest.code_by_id(1);
+        if let Some(code) = system {
+            map.insert(*code, vm_api::builtin::Type::System);
+        }
+
         let init = manifest.code_by_id(2);
         if let Some(code) = init {
             map.insert(*code, vm_api::builtin::Type::Init);
@@ -195,12 +200,32 @@ where
 
         let verifreg = manifest.code_by_id(11);
         if let Some(code) = verifreg {
-            map.insert(*code, vm_api::builtin::Type::Reward);
+            map.insert(*code, vm_api::builtin::Type::VerifiedRegistry);
         }
 
         let datacap = manifest.code_by_id(12);
         if let Some(code) = datacap {
             map.insert(*code, vm_api::builtin::Type::DataCap);
+        }
+
+        let placeholder = manifest.code_by_id(13);
+        if let Some(code) = placeholder {
+            map.insert(*code, vm_api::builtin::Type::Placeholder);
+        }
+
+        let evm = manifest.code_by_id(14);
+        if let Some(code) = evm {
+            map.insert(*code, vm_api::builtin::Type::EVM);
+        }
+
+        let eam = manifest.code_by_id(15);
+        if let Some(code) = eam {
+            map.insert(*code, vm_api::builtin::Type::EAM);
+        }
+
+        let ethaccount = manifest.code_by_id(16);
+        if let Some(code) = ethaccount {
+            map.insert(*code, vm_api::builtin::Type::EthAccount);
         }
 
         map

--- a/vm/src/builder.rs
+++ b/vm/src/builder.rs
@@ -185,7 +185,7 @@ where
 
     /// Creates a workbench with the current state tree.
     /// The System and Init actors must be created before the workbench can be built or used.
-    fn build(&mut self) -> anyhow::Result<Box<dyn Bench>> {
+    fn build(&mut self, circulating_supply: TokenAmount) -> anyhow::Result<Box<dyn Bench>> {
         // Clone the context so the builder can be re-used for a new bench.
         let mut machine_ctx = self.machine_ctx.clone();
 
@@ -202,7 +202,9 @@ where
         let executor = DefaultExecutor::<
             BenchKernel<DefaultCallManager<DefaultMachine<B, FakeExterns>>>,
         >::new(EnginePool::new_default(engine_conf)?, machine)?;
-        Ok(Box::new(FvmBench::new(executor)))
+        let mut bench = FvmBench::new(executor);
+        bench.set_circulating_supply(circulating_supply);
+        Ok(Box::new(bench))
     }
 }
 


### PR DESCRIPTION
Closes #31 
Closes #28 

Previously, running the builtin-actor's state invariants check on genesis state of the workbench was revealing errors. 

These fixes ensure that the genesis state of the workbench is compliant with the expected invariants.