### PR TITLE
Allow tests to tweak per-epoch parameters 

### DIFF
--- a/api/src/bench.rs
+++ b/api/src/bench.rs
@@ -13,7 +13,6 @@ use crate::{ActorState, ExecutionResult};
 
 /// A factory for workbench instances.
 /// Built-in actors must be installed before the workbench can be created.
-// TODO: Configuration of default circulating supply, base fee etc.
 pub trait WorkbenchBuilder {
     type B: Blockstore;
 
@@ -57,12 +56,6 @@ pub trait Bench {
         msg_length: usize,
     ) -> anyhow::Result<ExecutionResult>;
 
-    /// Returns the VM's current epoch.
-    fn epoch(&self) -> ChainEpoch;
-
-    /// Replaces the VM in the workbench with a new set to the specified epoch
-    fn set_epoch(&mut self, epoch: ChainEpoch);
-
     /// Returns a reference to the VM's blockstore.
     fn store(&self) -> &dyn Blockstore;
 
@@ -85,12 +78,39 @@ pub trait Bench {
     /// Get a manifest of the builtin actors
     fn builtin_actors_manifest(&self) -> BTreeMap<Cid, vm_api::builtin::Type>;
 
+    /// Get a map of all address -> actor mappings in the state tree
+    fn actor_states(&self) -> BTreeMap<Address, ActorState>;
+
+    /// Get the VM's current epoch
+    fn epoch(&self) -> ChainEpoch;
+
+    /// Set the VM's current epoch
+    fn set_epoch(&mut self, epoch: ChainEpoch);
+
     /// Get the current circulating supply
     fn circulating_supply(&self) -> TokenAmount;
 
     /// Set the current circulating supply
     fn set_circulating_supply(&mut self, amount: TokenAmount);
 
-    /// Get a map of all address -> actor mappings in the state tree
-    fn actor_states(&self) -> BTreeMap<Address, ActorState>;
+    /// Get the current base fee
+    fn base_fee(&self) -> TokenAmount;
+
+    /// Set the current base fee
+    fn set_base_fee(&mut self, amount: TokenAmount);
+
+    /// Get the current timestamp
+    fn timestamp(&self) -> u64;
+
+    /// Set the current timestamp
+    fn set_timestamp(&mut self, timestamp: u64);
+
+    /// Get the initial state root of the block
+    fn initial_state_root(&self) -> Cid;
+
+    /// Set the initial state root of the block
+    fn set_initial_state_root(&mut self, state_root: Cid);
+
+    /// Toggle execution traces in the VM (default: true in the workbench)
+    fn set_tracing(&mut self, tracing: bool);
 }

--- a/vm/src/builder.rs
+++ b/vm/src/builder.rs
@@ -192,6 +192,7 @@ where
         // Flush the state tree to store and calculate the initial root.
         let state_root = self.state_tree.flush().map_err(anyhow::Error::from)?;
         machine_ctx.initial_state_root = state_root;
+        machine_ctx.circ_supply = circulating_supply;
 
         let engine_conf = (&machine_ctx.network).into();
         let machine = DefaultMachine::new(
@@ -202,8 +203,7 @@ where
         let executor = DefaultExecutor::<
             BenchKernel<DefaultCallManager<DefaultMachine<B, FakeExterns>>>,
         >::new(EnginePool::new_default(engine_conf)?, machine)?;
-        let mut bench = FvmBench::new(executor);
-        bench.set_circulating_supply(circulating_supply);
+        let bench = FvmBench::new(executor);
         Ok(Box::new(bench))
     }
 }


### PR DESCRIPTION
https://github.com/anorth/fvm-workbench/issues/36

Per-epoch values that are injected into the virtual machine (via MachineContext) can now be tweaked at the Bench level. 

This will be exposed to the Execution wrangler when the vm_api::VM trait is updated in builtin-actors with the same functionality. 

It is difficult to do the same for the settings in NetworkConfig as there is a huge surface area to cover and many fields are types internal to the FVM. Providing methods to tweak MachineContext or NetworkConfig wholesale would leak these types.

i.e. while it is possible to write the following utility code in `vm/src/bench`
```
    fn modify_network_cfg<F>(&mut self, modify_cfg: F)
    where
        F: Fn(&mut NetworkConfig),
    {
        self.modify_machine_ctx(|ctx| {
            modify_cfg(&mut ctx.network);
        });
    }
```
exposing any of the functionality within the api crate is messier to achieve.



This can be addressed in a followup if necessary. The VM API could define a new type that abstracts the pertinent fields of MachineContext and NetworkConfig.